### PR TITLE
Add redirection from 404 to index

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "start": "react-scripts start",
     "now-start": "serve --single ./build",
     "build": "react-scripts build",
+    "deploy": "react-scripts build && cp build/index.html build/404.html",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "format": "./node_modules/.bin/prettier --write 'src/**/*.{js,json,css}'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@
 [build]
   base    = "client"
   publish = "client/build"
-  command = "yarn build"
+  command = "yarn deploy"


### PR DESCRIPTION
Fix react-router not working with the Netlify build. Needed to redirect all 404 errors to index ([see article](https://hugogiraudel.com/2017/05/13/using-create-react-app-on-netlify/)).